### PR TITLE
Query async support

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -117,6 +117,31 @@ connection.query('SELECT 1 + 1 AS solution', function (error, results, fields) {
 connection.end();
 ```
 
+The `queryAsync` function provides support for Promises, allowing asynchronous execution of queries.
+
+```js
+var mysql = require('mysql');
+var connection = mysql.createConnection({
+  host: 'localhost',
+  user: 'me',
+  password: 'secret',
+  database: 'my_db'
+});
+
+connection.connect();
+
+connection.queryAsync('SELECT 1 + 1 AS solution')
+  .then((results) => {
+    console.log('The solution is: ', results[0].solution);
+  })
+  .catch((error) => {
+    throw error;
+  })
+  .finally(() => {
+    connection.end();
+  });
+```
+
 From this example, you can learn the following:
 
 * Every method you invoke on a connection is queued and executed in sequence.

--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -198,6 +198,36 @@ Connection.prototype.query = function query(sql, values, cb) {
   return this._protocol._enqueue(query);
 };
 
+Connection.prototype.queryAsync = function queryAsync(sql, values) {
+  return new Promise((resolve, reject) => {
+    var query = Connection.createQuery(sql, values, function (err, results) {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(results);
+      }
+    });
+
+    query._connection = this;
+
+    if (!(typeof sql === 'object' && 'typeCast' in sql)) {
+      query.typeCast = this.config.typeCast;
+    }
+
+    if (query.sql) {
+      query.sql = this.format(query.sql, query.values);
+    }
+
+    if (query._callback) {
+      query._callback = wrapCallbackInDomain(this, query._callback);
+    }
+
+    this._implyConnect();
+
+    this._protocol._enqueue(query);
+  });
+};
+
 Connection.prototype.ping = function ping(options, callback) {
   if (!callback && typeof options === 'function') {
     callback = options;

--- a/test/unit/connection/test-query-async.js
+++ b/test/unit/connection/test-query-async.js
@@ -1,0 +1,33 @@
+var after  = require('after');
+var assert = require('assert');
+var common = require('../../common');
+
+var server = common.createFakeServer();
+
+server.listen(0, function (err) {
+  assert.ifError(err);
+
+  var connection = common.createConnection({port: server.port()});
+
+  var done = after(2, function () {
+    server.destroy();
+  });
+
+  connection.connect(assert.ifError);
+
+  connection.end(function (err) {
+    assert.ifError(err);
+    done();
+  });
+
+  connection.queryAsync('SELECT 1')
+    .then(function () {
+      done(new Error('Query should have failed after connection end'));
+    })
+    .catch(function (err) {
+      assert.ok(err);
+      assert.equal(err.fatal, false);
+      assert.equal(err.code, 'PROTOCOL_ENQUEUE_AFTER_QUIT');
+      done();
+    });
+});


### PR DESCRIPTION
This pull request introduces the queryAsync function to the MySQL driver for Node.js. The purpose of this addition is to provide a promise-based alternative to the existing query function, enhancing the flexibility of handling asynchronous operations.

What: Added queryAsync function to the Connection prototype. The function works similarly to query but returns a promise instead of using a callback.

Why: Enables developers to use modern async/await patterns for database queries. Offers a more straightforward and concise syntax for handling asynchronous database operations.

Aligns with industry trends favoring promise-based APIs over traditional callback patterns. This enhancement aims to improve the overall usability and developer experience when interacting with the MySQL driver by providing an alternative asynchronous interface.

Please review and consider merging these changes. If you have any questions or suggestions, feel free to discuss them. Thank you!